### PR TITLE
Add stint information next to name links

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -49,6 +49,18 @@ CREATE TABLE IF NOT EXISTS stints (
   PRIMARY KEY (person_id, start_date)
 );
 
+CREATE VIEW stints_for_people AS
+SELECT
+  stints.person_id,
+  stints.stint_type,
+  stints.title,
+  stints.start_date,
+  batches.short_name
+FROM stints
+LEFT JOIN batches
+  ON stints.batch_id = batches.batch_id
+ORDER BY stints.start_date;
+
 CREATE VIEW geolocations_with_affiliated_people AS
 SELECT
   l.location_id,

--- a/src/components/map/LocationPopup.js
+++ b/src/components/map/LocationPopup.js
@@ -69,6 +69,75 @@ function Person({ person }) {
                 rel="noopener noreferrer">
                 {[person["first_name"], person["last_name"]].join(" ")}
             </a>
+
+            <StintInfo stints={person["stints"]} />
         </li>
     );
 }
+
+function StintInfo({ stints }) {
+    let stint_info = new Set(stints.map(s => stintToString(s)));
+
+    if (stint_info) {
+        stint_info = ` (${stintListToString([...stint_info])})`;
+    }
+
+    return <span className="stint-info">{stint_info}</span>;
+}
+
+/* For a list with at least two elements, return comma-separated
+ * head elements with ampersand separating last two elements,
+ * e.g. 1: 'A', 2: 'A & B', 3: 'A, B & C', 4: 'A, B, C & D', etc.
+ */
+const stintListToString = list => {
+    if (!list || list.length === 0) return "";
+
+    if (list.length === 1) return list[0];
+
+    let result = "";
+    for (let i = 0; i < list.length; i++) {
+        if (i === list.length - 1) {
+            result += " & ";
+        }
+
+        result += list[i];
+
+        if (i < list.length - 2) {
+            result += ", ";
+        }
+    }
+
+    return result;
+};
+
+const stintToString = stint => {
+    let type = stint["stint_type"];
+
+    if (!type) {
+        return "";
+    }
+
+    switch (type) {
+        case "retreat":
+            return stint["batch_name"];
+        case "residency":
+            type = "Resident";
+            break;
+        case "employment":
+            type = stint["rc_title"] || "Staff";
+            break;
+        case "experimental":
+            type = "Exp. Batch";
+            break;
+        case "research_fellowship":
+            type = "Fellow";
+            break;
+        case "facilitatorship":
+            type = "Facilitator";
+            break;
+        default:
+            type = type.charAt(0).toUpperCase() + type.slice(1);
+    }
+
+    return type;
+};

--- a/src/css/popup.css
+++ b/src/css/popup.css
@@ -1,21 +1,36 @@
 .leaflet-popup-content-wrapper {
-    width: 20vw;
+    width: 100%;
     max-height: 60vh;
 }
 
 .leaflet-popup-content {
     flex: auto;
-    font-size: 1vw;
-    max-width: 16vw;
+    max-width: 30vw;
+    width: 100%;
 }
 
 .location-popup .location-name {
     font-weight: bold;
-    font-size: 1.3vw;
+    font-size: 20px;
     text-align: center;
 }
 
 .location-popup .location-stats {
     font-style: italic;
     text-align: center;
+}
+
+.leaflet-popup-content {
+    max-width: 90%;
+    max-height: 60%;
+    font-size: 16px;
+    margin: 1.5em;
+}
+
+.leaflet-popup-content p {
+    margin: 1em;
+}
+
+.leaflet-popup-content ul {
+    padding-inline-start: 1.5em;
 }


### PR DESCRIPTION
This commit resolves #3 by adding information about stints or other affiliation next to each RCer's name. 

The batch `short_name` (e.g. "S1'14") is shown for each batch stint, otherwise, a shortened string based on the `stint_type` is returned, e.g. "Fellow" for "research_fellowship" or "Facilitator" for "facilitatorship".

