### PR TITLE
Reuse connection for subsequent API requests

### DIFF
--- a/update_data.py
+++ b/update_data.py
@@ -36,14 +36,14 @@ def getEnvVar(var_name, fallback=""):
 def get_people(token):
     people = []
 
-    headers = {'Authorization': f'Bearer {token}'}
+    session = requests.session()
+    session.headers.update({'Authorization': f'Bearer {token}'})
     url = 'https://www.recurse.com/api/v1/profiles?limit={limit}&offset={offset}'
     limit = 50
     offset = 0
 
     while True:
-        r = requests.get(url.format(
-            limit=limit, offset=offset), headers=headers)
+        r = session.get(url.format(limit=limit, offset=offset))
         if r.status_code != requests.codes.ok:
             r.raise_for_status()
         page = r.json()


### PR DESCRIPTION
Use a session so that requests to the Recurse Center API reuse the connection created by the first request, rather than set up a new connection for each request. This should both improve performance of the update and reduce the load imposed on recurse.com.

This can be seen by setting the log level to DEBUG and watching for lines like this:

    DEBUG:urllib3.connectionpool:Starting new HTTPS connection (1): www.recurse.com:443

After this change, there should only be one such log line.

See also:
- https://2.python-requests.org//en/latest/user/advanced/#keep-alive
- https://github.com/jasonaowen/recurse-faces/pull/62