### PR TITLE
Use location aliases to ensure unique lat/lng for geolocations

### DIFF
--- a/insert_rc_data.py
+++ b/insert_rc_data.py
@@ -58,6 +58,7 @@ def replace_data(database_url, people):
 
 def delete_data(cursor):
     cursor.execute('DELETE FROM geolocations')
+    cursor.execute('DELETE FROM location_aliases')
     cursor.execute('DELETE FROM location_affiliations')
     cursor.execute('DELETE FROM locations')
     cursor.execute('DELETE FROM stints')

--- a/schema.sql
+++ b/schema.sql
@@ -1,29 +1,29 @@
 CREATE TABLE IF NOT EXISTS batches (
   batch_id INTEGER PRIMARY KEY,
   name TEXT UNIQUE NOT NULL,
-  short_name TEXT
+  short_name TEXT NULL
 );
 
 CREATE TABLE IF NOT EXISTS people (
   person_id INTEGER PRIMARY KEY,
-  first_name TEXT,
-  middle_name TEXT,
-  last_name TEXT,
-  image_url TEXT
+  first_name TEXT NOT NULL,
+  middle_name TEXT NULL,
+  last_name TEXT NOT NULL,
+  image_url TEXT NULL
 );
 
 CREATE TABLE IF NOT EXISTS locations (
   location_id INTEGER PRIMARY KEY,
-  name TEXT,
-  short_name TEXT
+  name TEXT NOT NULL,
+  short_name TEXT NULL
 );
 
 CREATE TABLE IF NOT EXISTS geolocations (
-  location_id INTEGER NULL REFERENCES locations (location_id),
+  location_id INTEGER REFERENCES locations (location_id) PRIMARY KEY,
   name TEXT NOT NULL,
   type TEXT NOT NULL,
-  subdivision_derived TEXT,
-  subdivision_code TEXT,
+  subdivision_derived TEXT NULL,
+  subdivision_code TEXT NULL,
   country_name TEXT NOT NULL,
   country_code TEXT NOT NULL,
   lat TEXT NOT NULL,
@@ -33,9 +33,9 @@ CREATE TABLE IF NOT EXISTS geolocations (
 CREATE TABLE IF NOT EXISTS location_affiliations (
   person_id INTEGER NOT NULL REFERENCES people (person_id),
   location_id INTEGER NULL REFERENCES locations (location_id),
-  start_date DATE,
-  end_date DATE,
-  affiliation_type TEXT,
+  start_date DATE NULL,
+  end_date DATE NULL,
+  affiliation_type TEXT NULL,
   PRIMARY KEY (person_id, location_id)
 );
 
@@ -45,8 +45,13 @@ CREATE TABLE IF NOT EXISTS stints (
   stint_type TEXT NOT NULL,
   start_date DATE NOT NULL,
   end_date DATE NULL,
-  title TEXT,
+  title TEXT NULL,
   PRIMARY KEY (person_id, start_date)
+);
+
+CREATE TABLE IF NOT EXISTS location_aliases (
+  location_id INTEGER NOT NULL REFERENCES locations (location_id) PRIMARY KEY,
+  preferred_location_id INTEGER NOT NULL REFERENCES locations (location_id)
 );
 
 CREATE VIEW stints_for_people AS

--- a/worldmap.py
+++ b/worldmap.py
@@ -25,7 +25,7 @@ from flask import Flask, jsonify, redirect, request, send_from_directory, sessio
 from authlib.flask.client import OAuth
 from werkzeug.exceptions import HTTPException
 import psycopg2
-from geocode_locations import get_env_var, insert_geo_data
+from geocode_locations import get_env_var, lookup_and_insert_geodata
 
 
 # pylint: disable=invalid-name

--- a/worldmap.py
+++ b/worldmap.py
@@ -124,58 +124,6 @@ def needs_authorization(route):
     return wrapped_route
 
 
-def group_people_by_location(locations):
-    grouped_locations = []
-
-    # Use common location info as grouping key
-    for location_key, group in groupby(locations, lambda loc: {
-        "location_id": loc["location_id"],
-        "location_name": loc["location_name"],
-        "lat": loc["lat"],
-        "lng": loc["lng"],
-        "has_rc_people": loc["has_rc_people"]
-    }):
-        # Join all person information into a list for each location
-        person_list = [{
-            "person_id": location["person_id"],
-            "first_name": location["first_name"],
-            "last_name": location["last_name"],
-            "image_url": location["image_url"],
-            "stint_type": location["stint_type"],
-            "rc_title": location["rc_title"],
-            "batch_name": location["batch_name"]
-        } for location in group]
-
-        person_list_with_stints = group_stints_by_person(person_list)
-        location_key["person_list"] = person_list_with_stints
-        grouped_locations.append(location_key)
-
-    return grouped_locations
-
-
-def group_stints_by_person(person_list):
-    grouped_stints = []
-
-    # Use common stint info as grouping key
-    for stint_key, group in groupby(person_list, lambda s: {
-        "person_id": s["person_id"],
-        "first_name": s["first_name"],
-        "last_name": s["last_name"],
-        "image_url": s["image_url"]
-    }):
-        # Join all stint information into a list for each person
-        stint_list = [{
-            "stint_type": stint["stint_type"],
-            "rc_title": stint["rc_title"],
-            "batch_name": stint["batch_name"]
-        } for stint in group]
-
-        stint_key["stints"] = stint_list
-        grouped_stints.append(stint_key)
-
-    return grouped_stints
-
-
 # @app.route('/api/locations/all')
 @needs_authorization
 def get_all_rc_locations():
@@ -212,43 +160,50 @@ def get_all_rc_locations():
 def get_all_rc_locations_with_people():
     cursor = connection.cursor()
 
+    # Query returns list of locations grouped in the format: 
+    # {
+    #   location_id: 
+    #   location_name:
+    #   lat:
+    #   lng: 
+    #   person_list: [
+    #     {
+    #        person_id:
+    #        first_name:
+    #        last_name:
+    #        stints: [
+    #          {
+    #            stint_type:
+    #            rc_title:
+    #            batch_name:
+    #            start_date:
+    #          }
+    #        ]
+    #     }
+    #   ]
+    # }
+
     """Returns all locations in the database
     with their geolocation data and all affiliated RC users."""
     cursor.execute("""SELECT
-                        g.location_id,
-                        g.location_name,
-                        g.lat,
-                        g.lng,
-                        g.person_id,
-                        g.first_name,
-                        g.last_name,
-                        g.image_url,
-                        s.stint_type,
-                        s.title,
-                        s.short_name,
-                        s.start_date
-                      FROM geolocations_with_affiliated_people as g
-                      INNER JOIN stints_for_people as s
-                        ON s.person_id = g.person_id
-                      ORDER BY location_id, first_name, person_id, start_date""")
+                        location_id,
+                        location_name,
+                        lat,
+                        lng,
+                        person_list
+                      FROM geolocations_people_and_stints_agg""")
+    
     locations = [{
         'location_id': x[0],
         'location_name': x[1],
         'lat': x[2],
         'lng': x[3],
         'has_rc_people': True,
-        'person_id': x[4],
-        'first_name': x[5],
-        'last_name': x[6],
-        'image_url': x[7],
-        'stint_type': x[8],
-        'rc_title': x[9],
-        'batch_name': x[10]
+        'person_list': x[4]
     } for x in cursor.fetchall()]
     cursor.close()
 
-    grouped = group_people_by_location(locations)
-    return jsonify(grouped)
+    return jsonify(locations)
 
 
 @app.route('/api/locations/search')
@@ -365,9 +320,7 @@ def find_location_with_coords(cursor, location):
 
     results = [{
         'location_id': x[0],
-        'location_name': x[1],
-        'lat': x[2],
-        'lng': x[3]
+        'location_name': x[1]
     } for x in cursor.fetchall()]
 
     return require_one(results, location["location_id"])
@@ -421,40 +374,23 @@ def get_geolocation_with_people(cursor, location_id):
     ))
     """Returns the requested geolocation data for a location with the given id."""
     cursor.execute("""SELECT
-                        g.location_id,
-                        g.location_name,
-                        g.lat,
-                        g.lng,
-                        g.person_id,
-                        g.first_name,
-                        g.last_name,
-                        g.image_url,
-                        s.stint_type,
-                        s.title,
-                        s.short_name,
-                        s.start_date
-                      FROM geolocations_with_affiliated_people as g
-                      INNER JOIN stints_for_people as s
-                      ON s.person_id = g.person_id
-                      WHERE location_id = %s
-                      ORDER BY location_id, first_name, person_id, start_date""", [location_id])
+                        location_id,
+                        location_name,
+                        lat,
+                        lng,
+                        person_list
+                      FROM geolocations_people_and_stints_agg
+                      WHERE location_id = %s""", [location_id])
     locations = [{
         'location_id': x[0],
         'location_name': x[1],
         'lat': x[2],
         'lng': x[3],
         'has_rc_people': True,
-        'person_id': x[4],
-        'first_name': x[5],
-        'last_name': x[6],
-        'image_url': x[7],
-        'stint_type': x[8],
-        'rc_title': x[9],
-        'batch_name': x[10]
+        'person_list': x[4]
     } for x in cursor.fetchall()]
 
-    grouped = group_people_by_location(locations)
-    return require_one(grouped, location_id)
+    return require_one(locations, location_id)
 
 
 def require_one(location_arr, location_id):


### PR DESCRIPTION
This branch resolves #12 by introducing a new `location_aliases` table that tracks locations with duplicate latitude and longitude values to their preferred locations. The preferred location is defined as the one with the most RCers. 

Now, the `geocoding.py` script has a final deduplication step that checks the database for duplicate lat/lng values in the `geolocations` table, groups them by RC population, and then re-maps all RCers from the aliased locations to their preferred locations. The backend `worldmap.py` script now also checks this aliases table before returning results to the API.

For a concrete example, searching the [RC directory](https://www.recurse.com/directory?location=North+Providence%2C+RI) will show one RCer in "North Providence, RI", which has the same lat/lng as "Providence, RI" with two RCers. After this change, the lone RCer in North Providence will be assigned to Providence, and a search for "Providence, RI" will display all three RCers mentioned above. 

This also means that searches for "Singapore" and "Singapore, Singapore" will return the same result, as will "Hong Kong" and "Hong Kong, Hong Kong." This also resolves the issue with "Manhattan, NY" vs "New York City, NY"; all RCers will be returned as "New York City, NY". 

Although some RCers will no longer be displayed with the same exact location name as listed in their RC profiles, I think this is outweighed by the fact that some markers weren't displayed at all, as their marker was overlapped by another. 