### PR TITLE
Add profile photos to LocationPopup

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -6,9 +6,7 @@ CREATE TABLE IF NOT EXISTS batches (
 
 CREATE TABLE IF NOT EXISTS people (
   person_id INTEGER PRIMARY KEY,
-  first_name TEXT NOT NULL,
-  middle_name TEXT NULL,
-  last_name TEXT NOT NULL,
+  name TEXT NOT NULL,
   image_url TEXT NULL
 );
 
@@ -89,8 +87,7 @@ SELECT
   l.lat,
   l.lng,
   p.person_id,
-  p.first_name,
-  p.last_name,
+  p.name as person_name,
   p.image_url
 FROM geolocations l
   INNER JOIN location_affiliations a
@@ -108,12 +105,11 @@ SELECT
   json_agg(
       json_build_object(
           'person_id', g.person_id, 
-          'first_name', first_name, 
-          'last_name', last_name,
+          'name', person_name, 
           'image_url', image_url,
           'stints', stints
       )
-      ORDER BY first_name
+      ORDER BY person_name
   ) as person_list
 FROM geolocations_with_affiliated_people as g
 INNER JOIN stints_for_people_agg as s

--- a/src/components/Navbar.js
+++ b/src/components/Navbar.js
@@ -9,7 +9,7 @@ export default function Navbar({ ...props }) {
     <nav className="navbar navbar-light navbar-expand">
       <Link to="/" className="navbar-brand">
         <img src={MapIcon} alt="RC Map Icon" />
-        <span class="text-collapsible d-none d-md-inline">
+        <span className="text-collapsible d-none d-md-inline">
           World of Recurse
         </span>
       </Link>

--- a/src/components/map/LocationPopup.js
+++ b/src/components/map/LocationPopup.js
@@ -7,82 +7,80 @@ import "../../css/popup.css";
  * directory entries
  */
 export default function LocationPopup({ locationName, people, hasPeople }) {
-    return (
-        <Popup key={locationName} maxHeight="200">
-            <div className="location-popup">
-                <p className="location-name">{locationName}</p>
+  return (
+    <Popup key={locationName} maxHeight="200">
+      <div className="location-popup">
+        <p className="location-name">{locationName}</p>
 
-                {hasPeople ? <PeopleData people={people} /> : <NoPeople />}
-            </div>
-        </Popup>
-    );
+        {hasPeople ? <PeopleData people={people} /> : <NoPeople />}
+      </div>
+    </Popup>
+  );
 }
 
 function PeopleData({ people }) {
-    return (
-        <div className="person-data">
-            {people ? <People people={people} /> : <UnspecifiedPeople />}
-        </div>
-    );
+  return (
+    <div className="person-data">
+      {people ? <People people={people} /> : <UnspecifiedPeople />}
+    </div>
+  );
 }
 
 function NoPeople() {
-    return (
-        <span className="empty-person-list">
-            There are currently no RCers at this location.
-        </span>
-    );
+  return (
+    <span className="empty-person-list">
+      There are currently no RCers at this location.
+    </span>
+  );
 }
 
 function UnspecifiedPeople() {
-    return (
-        <span className="unspecified-people">
-            There are RCers at this location. Login for more information!
-        </span>
-    );
+  return (
+    <span className="unspecified-people">
+      There are RCers at this location. Login for more information!
+    </span>
+  );
 }
 
 function People({ people }) {
-    const population = people.length;
-    const recursers = population === 1 ? "Recurser" : "Recursers";
+  const population = people.length;
+  const recursers = population === 1 ? "Recurser" : "Recursers";
 
-    return (
-        <>
-            <p className="location-stats">{population + " " + recursers}</p>
-            <ul className="person-list">
-                {people.map(p => (
-                    <Person key={p["person_id"]} person={p} />
-                ))}
-            </ul>
-        </>
-    );
+  return (
+    <>
+      <p className="location-stats">{population + " " + recursers}</p>
+      <ul className="person-list">
+        {people.map(p => (
+          <Person key={p["person_id"]} person={p} />
+        ))}
+      </ul>
+    </>
+  );
 }
 
 function Person({ person }) {
-    return (
-        <li>
-            <a
-                href={
-                    "https://www.recurse.com/directory/" + person["person_id"]
-                }
-                target="_blank"
-                rel="noopener noreferrer">
-                {[person["first_name"], person["last_name"]].join(" ")}
-            </a>
+  return (
+    <li>
+      <a
+        href={"https://www.recurse.com/directory/" + person["person_id"]}
+        target="_blank"
+        rel="noopener noreferrer">
+        {person["name"]}
+      </a>
 
-            <StintInfo stints={person["stints"]} />
-        </li>
-    );
+      <StintInfo stints={person["stints"]} />
+    </li>
+  );
 }
 
 function StintInfo({ stints }) {
-    let stint_info = new Set(stints.map(s => stintToString(s)));
+  let stint_info = new Set(stints.map(s => stintToString(s)));
 
-    if (stint_info) {
-        stint_info = ` (${stintListToString([...stint_info])})`;
-    }
+  if (stint_info) {
+    stint_info = ` (${stintListToString([...stint_info])})`;
+  }
 
-    return <span className="stint-info">{stint_info}</span>;
+  return <span className="stint-info">{stint_info}</span>;
 }
 
 /* For a list with at least two elements, return comma-separated
@@ -90,54 +88,54 @@ function StintInfo({ stints }) {
  * e.g. 1: 'A', 2: 'A & B', 3: 'A, B & C', 4: 'A, B, C & D', etc.
  */
 const stintListToString = list => {
-    if (!list || list.length === 0) return "";
+  if (!list || list.length === 0) return "";
 
-    if (list.length === 1) return list[0];
+  if (list.length === 1) return list[0];
 
-    let result = "";
-    for (let i = 0; i < list.length; i++) {
-        if (i === list.length - 1) {
-            result += " & ";
-        }
-
-        result += list[i];
-
-        if (i < list.length - 2) {
-            result += ", ";
-        }
+  let result = "";
+  for (let i = 0; i < list.length; i++) {
+    if (i === list.length - 1) {
+      result += " & ";
     }
 
-    return result;
+    result += list[i];
+
+    if (i < list.length - 2) {
+      result += ", ";
+    }
+  }
+
+  return result;
 };
 
 const stintToString = stint => {
-    let type = stint["stint_type"];
+  let type = stint["stint_type"];
 
-    if (!type) {
-        return "";
-    }
+  if (!type) {
+    return "";
+  }
 
-    switch (type) {
-        case "retreat":
-            return stint["batch_name"];
-        case "residency":
-            type = "Resident";
-            break;
-        case "employment":
-            type = stint["rc_title"] || "Staff";
-            break;
-        case "experimental":
-            type = "Exp. Batch";
-            break;
-        case "research_fellowship":
-            type = "Fellow";
-            break;
-        case "facilitatorship":
-            type = "Facilitator";
-            break;
-        default:
-            type = type.charAt(0).toUpperCase() + type.slice(1);
-    }
+  switch (type) {
+    case "retreat":
+      return stint["batch_name"];
+    case "residency":
+      type = "Resident";
+      break;
+    case "employment":
+      type = stint["rc_title"] || "Staff";
+      break;
+    case "experimental":
+      type = "Exp. Batch";
+      break;
+    case "research_fellowship":
+      type = "Fellow";
+      break;
+    case "facilitatorship":
+      type = "Facilitator";
+      break;
+    default:
+      type = type.charAt(0).toUpperCase() + type.slice(1);
+  }
 
-    return type;
+  return type;
 };

--- a/src/components/map/LocationPopup.js
+++ b/src/components/map/LocationPopup.js
@@ -49,28 +49,35 @@ function People({ people }) {
   return (
     <>
       <p className="location-stats">{population + " " + recursers}</p>
-      <ul className="person-list">
-        {people.map(p => (
-          <Person key={p["person_id"]} person={p} />
-        ))}
-      </ul>
+      {people.map(p => (
+        <Person key={p["person_id"]} person={p} />
+      ))}
     </>
   );
 }
 
 function Person({ person }) {
   return (
-    <li>
-      <a
-        href={"https://www.recurse.com/directory/" + person["person_id"]}
-        target="_blank"
-        rel="noopener noreferrer">
-        {person["name"]}
-      </a>
-
-      <StintInfo stints={person["stints"]} />
-    </li>
+    <a
+      className="person-link"
+      href={"https://www.recurse.com/directory/" + person["person_id"]}
+      target="_blank"
+      rel="noopener noreferrer">
+      <Photo imageUrl={person["image_url"]} personName={person["name"]} />
+      <div className="person-info">
+        <span className="person-name">{person["name"]}</span>
+        <StintInfo stints={person["stints"]} />
+      </div>
+    </a>
   );
+}
+
+function Photo({ imageUrl, personName }) {
+  return imageUrl ? (
+    <div className="profile-photo">
+      <img src={imageUrl} alt={personName + " photo"} />
+    </div>
+  ) : null;
 }
 
 function StintInfo({ stints }) {

--- a/src/css/popup.css
+++ b/src/css/popup.css
@@ -1,36 +1,58 @@
 .leaflet-popup-content-wrapper {
-    width: 100%;
-    max-height: 60vh;
+  width: 100%;
+  max-height: 60vh;
 }
 
 .leaflet-popup-content {
-    flex: auto;
-    max-width: 30vw;
-    width: 100%;
+  flex: auto;
+  max-width: 30vw;
+  width: 400px;
 }
 
 .location-popup .location-name {
-    font-weight: bold;
-    font-size: 20px;
-    text-align: center;
+  font-weight: bold;
+  font-size: 20px;
+  text-align: center;
 }
 
 .location-popup .location-stats {
-    font-style: italic;
-    text-align: center;
+  font-style: italic;
+  text-align: center;
 }
 
 .leaflet-popup-content {
-    max-width: 90%;
-    max-height: 60%;
-    font-size: 16px;
-    margin: 1.5em;
+  max-width: 90%;
+  max-height: 60%;
+  font-size: 16px;
+  margin: 1.5em;
 }
 
 .leaflet-popup-content p {
-    margin: 1em;
+  margin: 1em;
 }
 
 .leaflet-popup-content ul {
-    padding-inline-start: 1.5em;
+  padding-inline-start: 1.5em;
+}
+
+.person-link {
+  color: black;
+  display: flex;
+  align-items: center;
+}
+
+.profile-photo {
+  height: calc(80px + 2vw);
+  width: calc(80px + 2vw);
+  margin-right: 0.5rem;
+}
+
+.profile-photo img {
+  border-radius: 50%;
+  object-fit: none;
+  height: 100%;
+  border: 1px solid lightgray;
+  background: white;
+  box-shadow: 0 0 0 5px rgba(0, 0, 0, 0.03);
+  overflow: hidden;
 }

--- a/update_data.py
+++ b/update_data.py
@@ -66,8 +66,7 @@ def insert_people_data(cursor, people):
     for person in people:
         person_id = person.get('id')
         name = person.get('name')
-        image_path = person.get('image_path')
-        image_url = image_path if ("no_photo" not in image_path) else None
+        image_url = person.get('image_path')
 
         logging.debug("Person #{}: {}".format(
             person_id,

--- a/update_data.py
+++ b/update_data.py
@@ -65,38 +65,26 @@ def insert_people_data(cursor, people):
 
     for person in people:
         person_id = person.get('id')
+        name = person.get('name')
         image_path = person.get('image_path')
         image_url = image_path if ("no_photo" not in image_path) else None
 
-        first_name = person.get('first_name')
-        middle_name = person.get('middle_name')
-        last_name = person.get('last_name')
-
-        logging.debug("Person #{}: {} {} {}".format(
+        logging.debug("Person #{}: {}".format(
             person_id,
-            first_name,
-            middle_name,
-            last_name
+            name
         ))
 
         cursor.execute("INSERT INTO people" +
-                       " (person_id, first_name, middle_name," +
-                       "  last_name, image_url)" +
-                       " VALUES (%s, %s, %s, %s, %s)" +
+                       " (person_id, name, image_url)" +
+                       " VALUES (%s, %s, %s)" +
                        " ON CONFLICT (person_id) DO UPDATE SET" +
-                       " first_name = %s," +
-                       " middle_name = %s," +
-                       " last_name = %s," +
+                       " name = %s," +
                        " image_url = %s" +
                        " WHERE people.person_id = %s",
                        [person_id,
-                        first_name,
-                        middle_name,
-                        last_name,
+                        name,
                         image_url,
-                        first_name,
-                        middle_name,
-                        last_name,
+                        name,
                         image_url,
                         person_id
                         ]

--- a/worldmap.py
+++ b/worldmap.py
@@ -97,10 +97,7 @@ def auth_recurse_callback():
         }), 403)
 
     me = rc.get('people/me', token=token).json()
-    logging.info("Logged in: %s %s %s",
-                 me.get('first_name', ''),
-                 me.get('middle_name', ''),
-                 me.get('last_name', ''))
+    logging.info("Logged in: %s", me.get('name', ''))
 
     session['recurse_user_id'] = me['id']
     return redirect(url_for('index'))
@@ -169,8 +166,7 @@ def get_all_rc_locations_with_people():
     #   person_list: [
     #     {
     #        person_id:
-    #        first_name:
-    #        last_name:
+    #        person_name:
     #        stints: [
     #          {
     #            stint_type:
@@ -293,7 +289,7 @@ def get_alias(cursor, location_id):
     logging.info("Select Alias for Location ID #{}".format(
         location_id
     ))
-    """Returns the preferred location alias for the location 
+    """Returns the preferred location alias for the location
         with the given id if an alias exists."""
     cursor.execute("""SELECT
                         preferred_location_id


### PR DESCRIPTION
This commit changes the styling on the LocationPopup element by including RC Directory's profile photos. 

It also modifies the `update_data.py` script to use the profile `name` field instead of `first_name`, `middle_name`, and `last_name`. Also, the script no longer filters out the ['no_photo' photo](https://d29xw0ra2h4o4u.cloudfront.net/assets/people/no_photo_150-63579d0fab12c3d73ec0a2d65f7dfee8ee6c03771daddf3f2dc40487046038e8.jpg) and displays it, if present, next to the RCer's name on the LocationPopup. 