### PR TITLE
Change bubble radii calculation and scale 

### DIFF
--- a/src/components/map/LeafletMap.js
+++ b/src/components/map/LeafletMap.js
@@ -51,6 +51,8 @@ export default class LeafletMap extends React.Component {
 
     render() {
         const { locations, selected, isLoading, ...otherProps } = this.props;
+        const maxZoom = 11;
+
         return isLoading ? (
             <Spinner isLoading={isLoading} id="map-spinner" />
         ) : (
@@ -59,7 +61,7 @@ export default class LeafletMap extends React.Component {
                 ref="mapRef"
                 viewport={this.DEFAULT_VIEWPORT}
                 zoomSnap="0.2"
-                maxZoom={11}>
+                maxZoom={maxZoom}>
                 <TileLayer
                     attribution='&amp;copy <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
                     url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
@@ -67,7 +69,7 @@ export default class LeafletMap extends React.Component {
                 <LocationClusterGroup
                     fitBoundsTriggered={this.state.fitBoundsTriggered}
                     fitBoundsFn={this.fitBounds}
-                    maxClusterRadius="45"
+                    maxZoom={maxZoom}
                     locations={locations}
                     selected={selected}
                     padding={this.DEFAULT_PADDING}

--- a/src/components/map/LocationMarker.js
+++ b/src/components/map/LocationMarker.js
@@ -3,103 +3,91 @@ import L from "leaflet";
 import { Marker } from "react-leaflet";
 
 import LocationPopup from "./LocationPopup";
+import { populationToRadius, populationToSize } from "./RadiusUtil";
 
 export default class LocationMarker extends React.Component {
-  componentDidMount() {
-    let { isSelected, zoomToShowMarkerFn } = this.props;
+    componentDidMount() {
+        let { isSelected, zoomToShowMarkerFn } = this.props;
 
-    const markerRef = this.refs.markerRef;
+        const markerRef = this.refs.markerRef;
 
-    if (isSelected && markerRef) {
-      const leafletMarker = markerRef.leafletElement;
-      zoomToShowMarkerFn(leafletMarker);
-    }
-  }
-
-  componentDidUpdate(prevProps) {
-    let {
-      isSelected,
-      zoomToShowMarkerFn,
-      isVisible,
-      onPopupDisplayedFn
-    } = this.props;
-
-    const markerRef = this.refs.markerRef;
-
-    if (markerRef) {
-      const leafletMarker = markerRef.leafletElement;
-
-      if (isSelected && !prevProps.isSelected) {
-        // Call function to zoom to the boundaries of the selected marker
-        // then open its popup
-        zoomToShowMarkerFn(leafletMarker);
-      }
-
-      if (isSelected && !prevProps.isVisible && isVisible) {
-        leafletMarker.openPopup();
-        onPopupDisplayedFn();
-      }
-
-      if (!isSelected) {
-        leafletMarker.closePopup();
-      }
-    }
-  }
-
-  render() {
-    const { location, isSelected } = this.props;
-
-    const people = location["person_list"];
-    const population = people ? people.length : 0;
-    const hasPeople = !!location["has_rc_people"];
-
-    if (population === 0 && !isSelected && !hasPeople) {
-      return null;
+        if (isSelected && markerRef) {
+            const leafletMarker = markerRef.leafletElement;
+            zoomToShowMarkerFn(leafletMarker);
+        }
     }
 
-    return (
-      <Marker
-        ref="markerRef"
-        position={[parseFloat(location["lat"]), parseFloat(location["lng"])]}
-        className="location-marker"
-        population={population}
-        icon={circleIcon(population)}>
-        <LocationPopup key={location["location_id"]} location={location} />
-      </Marker>
-    );
-  }
+    componentDidUpdate(prevProps) {
+        let {
+            isSelected,
+            zoomToShowMarkerFn,
+            isVisible,
+            onPopupDisplayedFn
+        } = this.props;
+
+        const markerRef = this.refs.markerRef;
+
+        if (markerRef) {
+            const leafletMarker = markerRef.leafletElement;
+
+            if (isSelected && !prevProps.isSelected) {
+                // Call function to zoom to the boundaries of the selected marker
+                // then open its popup
+                zoomToShowMarkerFn(leafletMarker);
+            }
+
+            if (isSelected && !prevProps.isVisible && isVisible) {
+                leafletMarker.openPopup();
+                onPopupDisplayedFn();
+            }
+
+            if (!isSelected) {
+                leafletMarker.closePopup();
+            }
+        }
+    }
+
+    render() {
+        const { location, isSelected } = this.props;
+
+        const people = location["person_list"];
+        const population = people ? people.length : 0;
+        const hasPeople = !!location["has_rc_people"];
+
+        if (population === 0 && !isSelected && !hasPeople) {
+            return null;
+        }
+
+        return (
+            <Marker
+                ref="markerRef"
+                position={[
+                    parseFloat(location["lat"]),
+                    parseFloat(location["lng"])
+                ]}
+                className="location-marker"
+                population={population}
+                icon={circleIcon(population)}>
+                <LocationPopup
+                    key={location["location_id"]}
+                    location={location}
+                />
+            </Marker>
+        );
+    }
 }
 
-/* Use approx fibonacci seq to scale sizes of markers */
-const getProps = size => {
-  const popToRadius = {
-    1: { radius: 20, class: "sm" },
-    2: { radius: 30, class: "sm" },
-    5: { radius: 35, class: "sm" },
-    10: { radius: 50, class: "sm" },
-    20: { radius: 65, class: "lg" },
-    50: { radius: 80, class: "lg" },
-    100: { radius: 90, class: "xl" },
-    200: { radius: 100, class: "xl" },
-    400: { radius: 150, class: "xxl" },
-    5000: { radius: 500, class: "xxl" }
-  };
-  // Find the first key that is greater than the original size
-  const pop = Object.keys(popToRadius).filter(n => n >= size)[0];
-  return popToRadius[pop];
-};
-
 const circleIcon = population => {
-  const props = getProps(population);
-  const radius = props["radius"];
-  const html = population !== 0 ? population : "";
+    const radius = populationToRadius(population);
+    const size = populationToSize(population);
+    const html = population !== 0 ? population : "";
 
-  return L.divIcon({
-    html: `<div><span>${html}</span></div>`,
-    iconSize: [radius, radius],
-    iconAnchor: [radius / 2, radius / 2],
-    popupAnchor: [0, 0],
-    shadowSize: [0, 0],
-    className: "circle-icon circle-icon-" + props["class"]
-  });
+    return L.divIcon({
+        html: `<div><span>${html}</span></div>`,
+        iconSize: [radius, radius],
+        iconAnchor: [radius / 2, radius / 2],
+        popupAnchor: [0, 0],
+        shadowSize: [0, 0],
+        className: "circle-icon circle-icon-" + size
+    });
 };

--- a/src/components/map/RadiusUtil.js
+++ b/src/components/map/RadiusUtil.js
@@ -1,0 +1,33 @@
+export const populationToRadius = population => {
+    const baseRadius = 20; // This radius is for a population of 1
+
+    /**
+     * Use base population area to find proportional
+     * area and radius for new population
+     */
+    const popMultiplier = Math.sqrt(population) * baseRadius;
+    /**
+     * Scale value so that min and max values are bounded.
+     * Max cluster population is around ~950 with a max radius of ~150
+     */
+    return Math.floor(popMultiplier / 5 + 14);
+};
+
+export const populationToSize = population => {
+    const popToSize = {
+        1: "sm",
+        2: "sm",
+        5: "md",
+        10: "md",
+        20: "lg",
+        50: "lg",
+        100: "lg",
+        200: "xl",
+        400: "xl",
+        5000: "xxl"
+    };
+
+    // Find the first key that is greater than or equal to the original size
+    const size = Object.keys(popToSize).filter(n => n >= population)[0];
+    return popToSize[size];
+};

--- a/src/css/map.css
+++ b/src/css/map.css
@@ -35,31 +35,8 @@
     align-items: center; /* align vertical */
 }
 
-.circle-cluster-sm div {
-    width: 30px;
-    height: 30px;
-}
-
-.circle-cluster-md div {
-    width: 40px;
-    height: 40px;
-}
-
-.circle-cluster-lg div {
-    width: 60px;
-    height: 60px;
-}
-
-.circle-cluster-xl div {
-    width: 80px;
-    height: 80px;
-}
-
-.circle-cluster-xxl div {
-    width: 100px;
-    height: 100px;
-}
-
+.circle-icon-sm div,
+.circle-cluster-sm div,
 .circle-icon-md div,
 .circle-cluster-md div,
 .circle-icon-lg div,

--- a/update_data.py
+++ b/update_data.py
@@ -202,7 +202,8 @@ def add_geolocation(cursor):
             insert_geo_data(cursor, geo)
 
         logging.info('Inserted %s locations', no_geo_count)
-        reconcile_duplicates(cursor)
+
+    reconcile_duplicates(cursor)
 
 
 def lookup_geodata(cursor, location):


### PR DESCRIPTION
This commit resolves #25 by changing how the radius of a population cluster or marker is calculated. 

Before, I used a rough Fibonacci sequence to scale the clusters and markers, and the scale for clusters and markers was slightly different. A few resources said that I should calculate the radius of the circles using the square root of the population difference so that the area scales proportionally. For example, if the radius for a circle for a population of 1 is 20px, then the radius for a population of two should be SQRT(2)*20. This way the area of the second circle will be twice that of the first. 
* Area of a 1 population circle: PI*SQRT(20)^2 
* Area of a 2 population circle: PI * SQRT(SQRT(2)*20)^2 = PI * **2** * SQRT(20)^2 = 2 * (Area of 1 population circle)

Using the square root formula alone meant that the circle sizes got wayyyy too large at higher ends of the population scale. For example, the max radius before was around 150px; the max radius for a comparable population was around 600px. So I scaled the radius sizes down by 75% so that they don't get too large but still scale proportionally.

Lastly, now the cluster and marker sizes are calculated with the same formula, so they will be the same size for the same population. The cluster still has an additional 10px translucent border to denote that it's a cluster. 