### PR TITLE
Fix minor style issues around bottom of screen

### DIFF
--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -3,7 +3,7 @@ import GitHubLogo from "../assets/GitHub-Mark-32px.png";
 
 export default function Footer() {
   return (
-    <footer className="footer mt-auto py-2 d-none d-lg-block">
+    <footer className="footer mt-auto py-2">
       <div className="footer-container container-fluid">
         <a
           href="http://www.recurse.com"

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -3,7 +3,7 @@ import GitHubLogo from "../assets/GitHub-Mark-32px.png";
 
 export default function Footer() {
   return (
-    <footer className="footer mt-auto py-2">
+    <footer className="footer py-2">
       <div className="footer-container container-fluid">
         <a
           href="http://www.recurse.com"

--- a/src/css/index.css
+++ b/src/css/index.css
@@ -56,7 +56,6 @@ ul.navbar-nav {
 }
 
 .footer {
-    height: 7%;
     bottom: 0;
     position: absolute;
     width: 100%;

--- a/src/css/index.css
+++ b/src/css/index.css
@@ -1,5 +1,5 @@
 body {
-    margin-bottom: 0.5em; /* Margin bottom by footer height */
+    margin: 0;
 }
 h1,
 h2,

--- a/src/css/index.css
+++ b/src/css/index.css
@@ -66,12 +66,6 @@ ul.navbar-nav {
     z-index: 999;
 }
 
-.footer-container {
-    height: 100%;
-    width: auto;
-    text-align: center;
-    margin: auto;
-}
 .footer-container a img {
     margin-left: 0.5em;
     margin-right: 0.5em;


### PR DESCRIPTION
Prevent the scrollbar from appearing by making the height of the content exactly equal to the screen height, always show the footer, delete some unneeded CSS rules, and reduce the height of the footer.

Before (note the empty white bar at the bottom of the image):
![Screen capture of current World of Recurse site, when viewed at 1000x600](https://user-images.githubusercontent.com/1494855/66687743-9abe5780-ec38-11e9-8309-28634b55d75f.png)

After:
![Screen capture of site with changes in this PR, when viewed at 1000x600](https://user-images.githubusercontent.com/1494855/66687744-9abe5780-ec38-11e9-9e94-322478646d68.png)

I chose 1000x600 for these images so that the footer would appear; previously, at lower horizontal resolutions, the footer would be hidden, as in this 800x600 shot:

![Screen capture of current site, with hidden footer, at 800x600](https://user-images.githubusercontent.com/1494855/66687898-4ebfe280-ec39-11e9-9eb7-68ca4d45ed7c.png)
